### PR TITLE
Add Client#find_by_slug method

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -26,6 +26,15 @@ module Wpclient
       Post.new(post)
     end
 
+    def find_by_slug(slug)
+      posts = parse_json_response(connection.get("posts", filter: {name: slug}))
+      if posts.size > 0
+        Post.new(posts.first)
+      else
+        raise NotFoundError, "Could not find post with slug #{slug.to_s.inspect}"
+      end
+    end
+
     def create_post(data)
       response = post_json("posts", data)
       if response.status == 201

--- a/spec/integration/posts_finding_spec.rb
+++ b/spec/integration/posts_finding_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe "Posts (finding)" do
+  before { WebMock.allow_net_connect! }
+
+  let(:client) {
+    server = WordpressServer.instance
+    Wpclient.new(url: server.url, username: server.username, password: server.password)
+  }
+
+  describe "finding by slug" do
+    it "finds the matching post" do
+      post = client.create_post(title: "Oh hai", slug: "oh-hai")
+      found = client.find_by_slug("oh-hai")
+      expect(found.id).to eq post.id
+    end
+
+    it "raises NotFoundError when no post can be found" do
+      expect {
+        client.find_by_slug("clearly-does-not-exist-anywhere")
+      }.to raise_error(Wpclient::NotFoundError, /clearly/)
+    end
+
+    it "finds on the slug even if the title is wildly different" do
+      post = client.create_post(
+        title: "Updated title that doesn't match slug",
+        slug: "original-concise-title",
+      )
+      found = client.find_by_slug("original-concise-title")
+      expect(found.id).to eq post.id
+    end
+  end
+end


### PR DESCRIPTION
This allows a client to find a post by its slug. I added no unit tests since nothing interesting is happening in the client and the integration tests already covers all existing cases.