### PR TITLE
Refactor Connection

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,9 +1,9 @@
 rspec_options = {
-  cmd: 'rspec -f documentation',
+  cmd: 'rspec -f documentation -t focus',
   failed_mode: :keep,
   all_after_pass: true,
   all_on_start: true,
-  run_all: {cmd: 'rspec -f progress'}
+  run_all: {cmd: 'rspec -f progress -t focus'}
 }
 
 guard :rspec, rspec_options do

--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ Run tests using the normal `rspec` command after installing all bundles. The fir
 bundle exec rspec
 ```
 
-You can also run `bundle exec guard` to have tests run automatically when you change files in the repo.
+You can also run `bundle exec guard` to have tests run automatically when you change files in the repo. If you tag your examples with `focus: true`, Guard will only run those tests. This can help when doing very focused coding, but remember to remove the filter before you commit and let the entire suite run.
+
+```ruby
+describe Foo, focus: true do
+  # ...
+end
+```
+
+The normal `rspec` command will *not* use this filter in case it is ever committed accidentally, so CI can catch any problems.
 
 ## Copyright & License
 

--- a/lib/wpclient.rb
+++ b/lib/wpclient.rb
@@ -1,6 +1,7 @@
 require "wpclient/version"
 require "wpclient/errors"
 
+require "wpclient/connection"
 require "wpclient/client"
 require "wpclient/category"
 require "wpclient/post"

--- a/lib/wpclient.rb
+++ b/lib/wpclient.rb
@@ -6,6 +6,8 @@ require "wpclient/client"
 require "wpclient/category"
 require "wpclient/post"
 
+require "wpclient/post_parser"
+
 require "wpclient/replace_categories"
 require "wpclient/replace_metadata"
 

--- a/lib/wpclient.rb
+++ b/lib/wpclient.rb
@@ -11,6 +11,6 @@ require "wpclient/replace_metadata"
 
 module Wpclient
   def self.new(*args)
-    Client.new(*args)
+    Client.new(Connection.new(*args))
   end
 end

--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -62,14 +62,6 @@ module Wpclient
       connection.patch(Category, "terms/category/#{id.to_i}", attributes)
     end
 
-    def assign_category_to_post(post_id:, category_id:)
-      connection.create_without_response("posts/#{post_id}/terms/category/#{category_id}", {})
-    end
-
-    def remove_category_from_post(post_id:, category_id:)
-      connection.delete("posts/#{post_id}/terms/category/#{category_id}", force: true)
-    end
-
     def assign_meta_to_post(post_id:, key:, value:)
       connection.create_without_response("posts/#{post_id}/meta", key: key, value: value)
     end
@@ -90,7 +82,7 @@ module Wpclient
     attr_reader :connection
 
     def assign_categories(post, category_ids)
-      ReplaceCategories.call(self, post, category_ids) if category_ids
+      ReplaceCategories.call(connection, post, category_ids) if category_ids
     end
 
     def assign_meta(post, meta)

--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -62,18 +62,6 @@ module Wpclient
       connection.patch(Category, "terms/category/#{id.to_i}", attributes)
     end
 
-    def assign_meta_to_post(post_id:, key:, value:)
-      connection.create_without_response("posts/#{post_id}/meta", key: key, value: value)
-    end
-
-    def remove_meta_from_post(post_id:, meta_id:)
-      connection.delete("posts/#{post_id}/meta/#{meta_id}", force: true)
-    end
-
-    def update_meta_on_post(post_id:, meta_id:, key:, value:)
-      connection.patch_without_response("posts/#{post_id}/meta/#{meta_id}", key: key, value: value)
-    end
-
     def inspect
       "#<Wpclient::Client #{connection.inspect}>"
     end
@@ -86,7 +74,7 @@ module Wpclient
     end
 
     def assign_meta(post, meta)
-      ReplaceMetadata.call(self, post, meta) if meta
+      ReplaceMetadata.call(connection, post, meta) if meta
     end
   end
 end

--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -3,13 +3,8 @@ require "json"
 
 module Wpclient
   class Client
-    attr_reader :url, :username
-
-    def initialize(url:, username:, password:)
-      @connection = Connection.new(url: url, username: username, password: password)
-      @url = url
-      @username = username
-      @password = password
+    def initialize(connection)
+      @connection = connection
     end
 
     def posts(per_page: 10, page: 1)

--- a/lib/wpclient/connection.rb
+++ b/lib/wpclient/connection.rb
@@ -12,7 +12,7 @@ module Wpclient
       model.parse(get_json(path, params))
     end
 
-    def get_multiple(model, path, params)
+    def get_multiple(model, path, params = {})
       get_json(path, params).map { |data| model.parse(data) }
     end
 

--- a/lib/wpclient/connection.rb
+++ b/lib/wpclient/connection.rb
@@ -1,0 +1,138 @@
+module Wpclient
+  class Connection
+    attr_reader :url, :username
+
+    def initialize(url:, username:, password:)
+      @url = url
+      @username = username
+      @password = password
+    end
+
+    def get(model, path, params = {})
+      model.parse(get_json(path, params))
+    end
+
+    def get_multiple(model, path, params)
+      get_json(path, params).map { |data| model.parse(data) }
+    end
+
+    def create(model, path, attributes, redirect_params: {})
+      response = send_json(path, attributes)
+
+      if response.status == 201 # Created
+        model.parse(get_json(response.headers.fetch("location"), redirect_params))
+      else
+        handle_status_code(response)
+        model.parse(parse_json_response(response))
+      end
+    end
+
+    def create_without_response(path, attributes)
+      response = send_json(path, attributes)
+
+      if response.status == 201 # Created
+        true
+      else
+        handle_status_code(response)
+        true
+      end
+    end
+
+    def delete(path, attributes = {})
+      response = send_json(path, attributes, method: :delete)
+      handle_status_code(response)
+      true
+    end
+
+    def patch(model, path, attributes)
+      model.parse(
+        parse_json_response(send_json(path, attributes, method: :patch))
+      )
+    end
+
+    def patch_without_response(path, attributes)
+      handle_status_code(send_json(path, attributes, method: :patch))
+      true
+    end
+
+    def inspect
+      "#<#{self.class.name} #@username @ #@url>"
+    end
+
+    private
+    def net
+      @net ||= setup_network_connection
+    end
+
+    def setup_network_connection
+      Faraday.new(url: "#{url}/wp/v2") do |conn|
+        conn.request :basic_auth, username, @password
+        conn.adapter :net_http
+      end
+    end
+
+    def get_json(path, params = {})
+      parse_json_response(net.get(path, params))
+    rescue Faraday::TimeoutError
+      raise TimeoutError
+    end
+
+    def send_json(path, data, method: :post)
+      unless %i[get post put patch delete].include? method
+        raise ArgumentError, "Invalid method: #{method.inspect}"
+      end
+
+      net.public_send(method) do |request|
+        json = data.to_json
+        request.url path
+        request.headers["Content-Type"] = "application/json; charset=#{json.encoding}"
+        request.body = json
+      end
+    rescue Faraday::TimeoutError
+      raise TimeoutError
+    end
+
+    def parse_json_response(response)
+      handle_status_code(response)
+
+      content_type = response.headers["content-type"].split(";").first
+      unless content_type == "application/json"
+        raise ServerError, "Got content type #{content_type}"
+      end
+
+      JSON.parse(response.body)
+
+    rescue JSON::ParserError => error
+      raise ServerError, "Could not parse JSON response: #{error}"
+    end
+
+    def handle_status_code(response)
+      case response.status
+      when 200
+        return
+      when 404
+        raise NotFoundError, "Could not find resource"
+      when 400
+        handle_bad_request(response)
+      else
+        raise ServerError, "Server returned status code #{response.status}: #{response.body}"
+      end
+    end
+
+    def handle_bad_request(response)
+      code, message = bad_request_details(response)
+      if code == "rest_post_invalid_id"
+        raise NotFoundError, "Post ID is not found"
+      else
+        raise ValidationError, message
+      end
+    end
+
+    def bad_request_details(response)
+      details = JSON.parse(response.body).first
+      [details["code"], details["message"]]
+    rescue
+      [nil, "Bad Request"]
+    end
+  end
+end

--- a/lib/wpclient/post.rb
+++ b/lib/wpclient/post.rb
@@ -9,87 +9,40 @@ module Wpclient
       :categories, :meta
     )
 
-    # TODO: Expand and replace the normal "new" method
-    def self.parse(*args) new(*args) end
+    def self.parse(data)
+      PostParser.parse(data)
+    end
 
-    def initialize(data)
-      @id = data["id"]
-      @url = data["link"]
-
-      @title = rendered(data, "title")
-      @guid = rendered(data, "guid")
-      @excerpt_html = rendered(data, "excerpt")
-      @content_html = rendered(data, "content")
-
-      @updated_at = read_date(data, "modified")
-      @date = read_date(data, "date")
-
-      @categories = read_categories(data)
-
-      @meta = {}
-      @meta_ids = {}
-      read_and_assign_metadata(data["_embedded"])
+    def initialize(
+      id:,
+      url:,
+      title:,
+      guid:,
+      excerpt_html:,
+      content_html:,
+      updated_at:,
+      date:,
+      categories: [],
+      meta: {},
+      meta_ids: {}
+    )
+      @id = id
+      @url = url
+      @title = title
+      @guid = guid
+      @excerpt_html = excerpt_html
+      @content_html = content_html
+      @updated_at = updated_at
+      @date = date
+      @categories = categories
+      @meta = meta
+      @meta_ids = meta_ids
     end
 
     def category_ids() categories.map(&:id) end
 
     def meta_id_for(key)
       @meta_ids[key] || raise(ArgumentError, "Post does not have meta #{key.inspect}")
-    end
-
-    private
-    def rendered(data, name)
-      (data[name] || {})["rendered"]
-    end
-
-    def read_date(data, name)
-      # Try to read UTC time first
-      if (gmt_time = data["#{name}_gmt"])
-        Time.iso8601("#{gmt_time}Z")
-      elsif (local_time = data[name])
-        Time.iso8601(local_time)
-      end
-    end
-
-    def read_categories(data)
-      embedded_terms(data, "category").map do |category|
-        Category.parse(category)
-      end
-    end
-
-    def read_and_assign_metadata(embeds)
-      embedded_metadata = embeds.fetch("http://v2.wp-api.org/meta", []).flatten
-      validate_embedded_metadata(embedded_metadata)
-
-      embedded_metadata.flatten.each do |entry|
-        @meta[entry.fetch("key")] = entry.fetch("value")
-        @meta_ids[entry.fetch("key")] = entry.fetch("id")
-      end
-    end
-
-    def embedded_terms(data, type)
-      term_collections = data.fetch("_embedded", {})["http://v2.wp-api.org/term"] || []
-
-      # term_collections is an array of arrays with terms in them. We can see
-      # the type of the "collection" by inspecting the first child's taxonomy.
-      term_collections.detect { |terms|
-        terms.size > 0 && terms.first["taxonomy"] == type
-      } || []
-    end
-
-    def validate_embedded_metadata(embedded_metadata)
-      if embedded_metadata.size == 1 && embedded_metadata.first["code"]
-        error = embedded_metadata.first
-        case error["code"]
-        when "rest_forbidden"
-          raise UnauthorizedError, error.fetch(
-            "message", "You are not authorized to see meta for this post."
-          )
-        else
-          raise Error, "Could not retreive meta for this post: " \
-            "#{error["code"]} – #{error["message"]}"
-        end
-      end
     end
   end
 end

--- a/lib/wpclient/post.rb
+++ b/lib/wpclient/post.rb
@@ -9,6 +9,9 @@ module Wpclient
       :categories, :meta
     )
 
+    # TODO: Expand and replace the normal "new" method
+    def self.parse(*args) new(*args) end
+
     def initialize(data)
       @id = data["id"]
       @url = data["link"]

--- a/lib/wpclient/post.rb
+++ b/lib/wpclient/post.rb
@@ -2,7 +2,7 @@ require "time"
 
 module Wpclient
   class Post
-    attr_reader(
+    attr_accessor(
       :id, :title, :url, :guid,
       :excerpt_html, :content_html,
       :updated_at, :date,
@@ -14,14 +14,14 @@ module Wpclient
     end
 
     def initialize(
-      id:,
-      url:,
-      title:,
-      guid:,
-      excerpt_html:,
-      content_html:,
-      updated_at:,
-      date:,
+      id: nil,
+      url: nil,
+      title: nil,
+      guid: nil,
+      excerpt_html: nil,
+      content_html: nil,
+      updated_at: nil,
+      date: nil,
       categories: [],
       meta: {},
       meta_ids: {}

--- a/lib/wpclient/post_parser.rb
+++ b/lib/wpclient/post_parser.rb
@@ -1,0 +1,101 @@
+module Wpclient
+  class PostParser
+    def self.parse(data)
+      new(data).to_post
+    end
+
+    def initialize(data)
+      @data = data
+    end
+
+    def to_post
+      @id = data["id"]
+      @url = data["link"]
+
+      @title = rendered("title")
+      @guid = rendered("guid")
+      @excerpt_html = rendered("excerpt")
+      @content_html = rendered("content")
+
+      @updated_at = read_date("modified")
+      @date = read_date("date")
+
+      @categories = read_categories(data)
+
+      @meta = {}
+      @meta_ids = {}
+      read_and_assign_metadata(data["_embedded"])
+
+      Post.new(
+        id: @id,
+        url: @url,
+        title: @title,
+        guid: @guid,
+        excerpt_html: @excerpt_html,
+        content_html: @content_html,
+        updated_at: @updated_at,
+        date: @date,
+        categories: @categories,
+        meta: @meta,
+        meta_ids: @meta_ids
+      )
+    end
+
+    private
+    attr_reader :data
+
+    def rendered(name)
+      (data[name] || {})["rendered"]
+    end
+
+    def read_date(name)
+      # Try to read UTC time first
+      if (gmt_time = data["#{name}_gmt"])
+        Time.iso8601("#{gmt_time}Z")
+      elsif (local_time = data[name])
+        Time.iso8601(local_time)
+      end
+    end
+
+    def read_categories(data)
+      embedded_terms(data, "category").map do |category|
+        Category.parse(category)
+      end
+    end
+
+    def read_and_assign_metadata(embeds)
+      embedded_metadata = embeds.fetch("http://v2.wp-api.org/meta", []).flatten
+      validate_embedded_metadata(embedded_metadata)
+
+      embedded_metadata.flatten.each do |entry|
+        @meta[entry.fetch("key")] = entry.fetch("value")
+        @meta_ids[entry.fetch("key")] = entry.fetch("id")
+      end
+    end
+
+    def embedded_terms(data, type)
+      term_collections = data.fetch("_embedded", {})["http://v2.wp-api.org/term"] || []
+
+      # term_collections is an array of arrays with terms in them. We can see
+      # the type of the "collection" by inspecting the first child's taxonomy.
+      term_collections.detect { |terms|
+        terms.size > 0 && terms.first["taxonomy"] == type
+      } || []
+    end
+
+    def validate_embedded_metadata(embedded_metadata)
+      if embedded_metadata.size == 1 && embedded_metadata.first["code"]
+        error = embedded_metadata.first
+        case error["code"]
+        when "rest_forbidden"
+          raise UnauthorizedError, error.fetch(
+            "message", "You are not authorized to see meta for this post."
+          )
+        else
+          raise Error, "Could not retreive meta for this post: " \
+            "#{error["code"]} – #{error["message"]}"
+        end
+      end
+    end
+  end
+end

--- a/lib/wpclient/replace_categories.rb
+++ b/lib/wpclient/replace_categories.rb
@@ -2,12 +2,12 @@ require "set"
 
 module Wpclient
   class ReplaceCategories
-    def self.call(client, post, category_ids)
-      new(client, post, category_ids).replace
+    def self.call(connection, post, category_ids)
+      new(connection, post, category_ids).replace
     end
 
-    def initialize(client, post, category_ids)
-      @client = client
+    def initialize(connection, post, category_ids)
+      @connection = connection
       @post = post
       @wanted_ids = category_ids.to_set
       @existing_ids = post.category_ids.to_set
@@ -19,7 +19,7 @@ module Wpclient
     end
 
     private
-    attr_reader :client, :post, :wanted_ids, :existing_ids
+    attr_reader :connection, :post, :wanted_ids, :existing_ids
 
     def categories_to_add
       wanted_ids - existing_ids
@@ -30,11 +30,11 @@ module Wpclient
     end
 
     def add_category_id(id)
-      client.assign_category_to_post(post_id: post.id, category_id: id)
+      connection.create_without_response("posts/#{post.id}/terms/category/#{id}", {})
     end
 
     def remove_category_id(id)
-      client.remove_category_from_post(post_id: post.id, category_id: id)
+      connection.delete("posts/#{post.id}/terms/category/#{id}", force: true)
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -82,7 +82,7 @@ describe Wpclient::Client do
       post = client.find_post(id)
       expect(post).to be_instance_of(Wpclient::Post)
       expect(post.id).to eq id
-      expect(post.title).to eq Wpclient::Post.new(post_fixture).title
+      expect(post.title).to eq Wpclient::Post.parse(post_fixture).title
     end
 
     it "raises a Wpclient::NotFoundError when post cannot be found" do
@@ -149,7 +149,7 @@ describe Wpclient::Client do
 
       post = client.update_post(42, title: "New title")
       expect(post).to be_instance_of(Wpclient::Post)
-      expect(post.title).to eq Wpclient::Post.new(post_fixture).title
+      expect(post.title).to eq Wpclient::Post.parse(post_fixture).title
     end
 
     it "raises ValidationError when server rejects changes" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,20 +1,11 @@
 require "spec_helper"
 
 describe Wpclient::Client do
-  let(:client) { Wpclient.new(url: "http://example.com", username: "x", password: "x") }
+  let(:connection) {
+    Wpclient::Connection.new(url: "http://example.com", username: "x", password: "x")
+  }
+  let(:client) { Wpclient::Client.new(connection) }
   let(:base_url) { "http://x:x@example.com" }
-
-  it "is initialized with connection details" do
-    client = Wpclient.new(url: "https://example.com/wp-json/", username: "user", password: "secret")
-    expect(client.url).to eq "https://example.com/wp-json/"
-    expect(client.username).to eq "user"
-  end
-
-  it "does not show password when inspected" do
-    client = Wpclient.new(url: "https://example.com/wp-json/", username: "x", password: "secret")
-    expect(client.to_s).to_not include "secret"
-    expect(client.inspect).to_not include "secret"
-  end
 
   describe "finding posts" do
     it "has working pagination" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Wpclient::Client  do
+describe Wpclient::Client do
   subject(:client) { Wpclient::Client.new(connection) }
   let(:connection) { instance_double(Wpclient::Connection) }
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+module Wpclient
+  describe Connection do
+    it "is constructed with a url, username and a password" do
+      connection = Connection.new(
+        url: "http://example.com/wp-json", username: "jane", password: "doe"
+      )
+
+      expect(connection.url).to eq('http://example.com/wp-json')
+    end
+  end
+end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -23,45 +23,48 @@ module Wpclient
 
     describe "get" do
       it "can get a single model" do
-        request_stub = stub_request(:get, "#{base_url}/foo?some_param=12").to_return(
-          body: '{"foo":"here"}',
-          headers: {"content-type" => "application/json; charset=utf-8"},
-        )
-        expect(model).to receive(:parse).with("foo" => "here").and_return(model_instance)
+        stub_get("#{base_url}/foo?some_param=12", returns: {title: "Foo"})
+        expect(model).to receive(:parse).with("title" => "Foo").and_return(model_instance)
         expect(connection.get(model, "foo", some_param: 12)).to eq model_instance
-        expect(request_stub).to have_been_made
       end
 
       it "can get several models" do
-        request_stub = stub_request(:get, "#{base_url}/foos?some_param=12").to_return(
-          body: '["result"]',
-          headers: {"content-type" => "application/json; charset=utf-8"},
-        )
+        stub_get("#{base_url}/foos?some_param=12", returns: ["result"])
         expect(model).to receive(:parse).with("result").and_return(model_instance)
         expect(connection.get_multiple(model, "foos", some_param: 12)).to eq [model_instance]
-        expect(request_stub).to have_been_made
+      end
+
+      it "raises Wpclient::TimeoutError when requests time out" do
+        stub_request(:get, /./).to_timeout
+        expect { connection.get(model, "foo") }.to raise_error(TimeoutError)
+        expect { connection.get_multiple(model, "foo") }.to raise_error(TimeoutError)
+      end
+
+      it "raises ServerError if response is invalid JSON" do
+        stub_get(/./, body: "[")
+        expect { connection.get(model, "foo") }.to raise_error(ServerError, /parse/)
+        expect { connection.get_multiple(model, "foo") }.to raise_error(ServerError, /parse/)
+      end
+
+      it "raises ServerError if response is not application/json" do
+        stub_get(/./, content_type: "text/plain")
+        expect { connection.get(model, "foo") }.to raise_error(ServerError, /plain/)
+        expect { connection.get_multiple(model, "foo") }.to raise_error(ServerError, /plain/)
+      end
+
+      it "raises NotFoundError if response is 404" do
+        stub_get(/./, status: 404)
+        expect { connection.get(model, "foo") }.to raise_error(NotFoundError)
+        expect { connection.get_multiple(model, "foo") }.to raise_error(NotFoundError)
       end
     end
 
     describe "creating" do
       it "can create models" do
-        encoding = "".encoding
-
-        stub_request(:post, "#{base_url}/foos").with(
-          headers: {"content-type" => "application/json; charset=#{encoding}"},
-          body: {"title" => "Bar"}.to_json,
-        ).to_return(
-          status: 201, # Created
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-            "Location" => "#{base_url}/foos/1"
-          }
+        stub_successful_post_with_redirect(
+          "#{base_url}/foos", {title: "Bar"}, redirects_to: "#{base_url}/foos/1"
         )
-
-        stub_request(:get, "#{base_url}/foos/1").to_return(
-          headers: {"content-type" => "application/json; charset=utf-8"},
-          body: {id: 1, title: "Bar"}.to_json,
-        )
+        stub_get("#{base_url}/foos/1", returns: {id: 1, title: "Bar"})
 
         expect(model).to receive(:parse).with(
           "id" => 1, "title" => "Bar"
@@ -72,17 +75,8 @@ module Wpclient
       end
 
       it "can ignore the response" do
-        encoding = "".encoding
-
-        stub_request(:post, "#{base_url}/foos").with(
-          headers: {"content-type" => "application/json; charset=#{encoding}"},
-          body: {"title" => "Bar"}.to_json,
-        ).to_return(
-          status: 201, # Created
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-            "Location" => "#{base_url}/foos/1"
-          }
+        stub_successful_post_with_redirect(
+          "#{base_url}/foos", {title: "Bar"}, redirects_to: "#{base_url}/foos/1"
         )
 
         response = connection.create_without_response("foos", title: "Bar")
@@ -90,40 +84,38 @@ module Wpclient
       end
 
       it "can pass extra parameters when following redirect" do
-        encoding = "".encoding
-
-        stub_request(:post, "#{base_url}/foos").with(
-          headers: {"content-type" => "application/json; charset=#{encoding}"},
-          body: {"title" => "Bar"}.to_json,
-        ).to_return(
-          status: 201, # Created
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-            "Location" => "#{base_url}/foos/1"
-          }
+        stub_successful_post_with_redirect(
+          "#{base_url}/foos", {title: "Bar"}, redirects_to: "#{base_url}/foos/1"
         )
-
-        redirect = stub_request(:get, "#{base_url}/foos/1?extra=param").to_return(
-          headers: {"content-type" => "application/json; charset=utf-8"},
-          body: "{}",
-        )
+        redirect = stub_get("#{base_url}/foos/1?extra=param", returns: {})
 
         connection.create(model, "foos", {title: "Bar"}, redirect_params: {extra: "param"})
         expect(redirect).to have_been_made
+      end
+
+      it "raises NotFoundError if response is 400 with rest_post_invalid_id as error code" do
+        stub_failing_post(/./, returns: json_fixture("invalid-post-id.json"), status: 400)
+
+        expect { connection.create(model, "foo", {}) }.to raise_error(NotFoundError, /post id/i)
+        expect { connection.create_without_response("foo", {}) }.to raise_error(NotFoundError)
+      end
+
+      it "raises ValidationError on any other 400 responses" do
+        stub_failing_post(/./, returns: json_fixture("validation-error.json"), status: 400)
+
+        expect {
+          connection.create(model, "foo", {})
+        }.to raise_error(ValidationError, /status is not one of/)
+
+        expect {
+          connection.create_without_response("foo", {})
+        }.to raise_error(ValidationError, /status is not one of/)
       end
     end
 
     describe "patching" do
       it "can patch models" do
-        encoding = "".encoding
-
-        stub_request(:patch, "#{base_url}/foos/1").with(
-          headers: {"content-type" => "application/json; charset=#{encoding}"},
-          body: {"title" => "Bar"}.to_json,
-        ).to_return(
-          headers: {"content-type" => "application/json; charset=utf-8"},
-          body: {id: 1, title: "Bar"}.to_json,
-        )
+        stub_patch("#{base_url}/foos/1", {title: "Bar"}, returns: {id: 1, title: "Bar"})
 
         expect(model).to receive(:parse).with(
           "id" => 1, "title" => "Bar"
@@ -134,18 +126,27 @@ module Wpclient
       end
 
       it "can ignore responses" do
-        encoding = "".encoding
-
-        stub_request(:patch, "#{base_url}/foos/1").with(
-          headers: {"content-type" => "application/json; charset=#{encoding}"},
-          body: {"title" => "Bar"}.to_json,
-        ).to_return(
-          headers: {"content-type" => "application/json; charset=utf-8"},
-          body: {id: 1, title: "Bar"}.to_json,
-        )
-
+        stub_patch("#{base_url}/foos/1", {title: "Bar"}, returns: {id: 1, title: "Bar"})
         response = connection.patch_without_response("foos/1", title: "Bar")
         expect(response).to be true
+      end
+
+      it "raises NotFoundError if response is 400 with rest_post_invalid_id as error code" do
+        stub_patch(/./, {}, returns: json_fixture("invalid-post-id.json"), status: 400)
+        expect { connection.patch(model, "foo", {}) }.to raise_error(NotFoundError, /post id/i)
+        expect { connection.patch_without_response("foo", {}) }.to raise_error(NotFoundError)
+      end
+
+      it "raises ValidationError on any other 400 responses" do
+        stub_patch(/./, {}, returns: json_fixture("validation-error.json"), status: 400)
+
+        expect {
+          connection.patch(model, "foo", {})
+        }.to raise_error(ValidationError, /status is not one of/)
+
+        expect {
+          connection.patch_without_response("foo", {})
+        }.to raise_error(ValidationError, /status is not one of/)
       end
     end
 
@@ -164,6 +165,61 @@ module Wpclient
         response = connection.delete("foos/1", force: true)
         expect(response).to be true
       end
+
+      it "raises ValidationError on 400 responses" do
+        stub_request(:delete, /./).to_return(
+          status: 400,
+          body: "{}",
+          headers: {"content-type" => "application/json; charset=utf-8"},
+        )
+
+        expect {
+          connection.delete("foo", {})
+        }.to raise_error(ValidationError)
+      end
+    end
+
+    def stub_get(
+      path,
+      returns: {},
+      status: 200,
+      body: returns.to_json,
+      content_type: "application/json"
+    )
+      stub_request(:get, path).to_return(
+        status: status,
+        body: body,
+        headers: {"content-type" => "#{content_type}; charset=utf-8"},
+      )
+    end
+
+    def stub_successful_post_with_redirect(path, data, redirects_to:)
+      stub_request(:post, path).with(
+        headers: {"content-type" => "application/json; charset=#{"".encoding}"},
+        body: data.to_json,
+      ).to_return(
+        status: 201, # Created
+        headers: {"Location" => redirects_to}
+      )
+    end
+
+    def stub_failing_post(path, returns:, status:)
+      stub_request(:post, path).to_return(
+        status: status,
+        body: returns.to_json,
+        headers: {"content-type" => "application/json; charset=utf-8"},
+      )
+    end
+
+    def stub_patch(path, data, returns:, status: 200)
+      stub_request(:patch, path).with(
+        headers: {"content-type" => "application/json; charset=#{"".encoding}"},
+        body: data.to_json,
+      ).to_return(
+        status: status,
+        headers: {"content-type" => "application/json; charset=utf-8"},
+        body: returns.to_json,
+      )
     end
   end
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -9,5 +9,11 @@ module Wpclient
 
       expect(connection.url).to eq('http://example.com/wp-json')
     end
+
+    it "does not show password when inspected" do
+      connection = Connection.new(url: "/", username: "x", password: "secret")
+      expect(connection.to_s).to_not include "secret"
+      expect(connection.inspect).to_not include "secret"
+    end
   end
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -2,11 +2,16 @@ require "spec_helper"
 
 module Wpclient
   describe Connection do
-    it "is constructed with a url, username and a password" do
-      connection = Connection.new(
-        url: "http://example.com/wp-json", username: "jane", password: "doe"
-      )
+    subject(:connection) {
+      Connection.new(url: "http://example.com/", username: "jane", password: "doe")
+    }
 
+    let(:base_url) { "http://jane:doe@example.com/wp/v2" }
+    let(:model) { class_double(Post, parse: model_instance) }
+    let(:model_instance) { instance_double(Post) }
+
+    it "is constructed with a url, username and a password" do
+      connection = Connection.new(url: "http://example.com/wp-json", username: "x", password: "x")
       expect(connection.url).to eq('http://example.com/wp-json')
     end
 
@@ -14,6 +19,151 @@ module Wpclient
       connection = Connection.new(url: "/", username: "x", password: "secret")
       expect(connection.to_s).to_not include "secret"
       expect(connection.inspect).to_not include "secret"
+    end
+
+    describe "get" do
+      it "can get a single model" do
+        request_stub = stub_request(:get, "#{base_url}/foo?some_param=12").to_return(
+          body: '{"foo":"here"}',
+          headers: {"content-type" => "application/json; charset=utf-8"},
+        )
+        expect(model).to receive(:parse).with("foo" => "here").and_return(model_instance)
+        expect(connection.get(model, "foo", some_param: 12)).to eq model_instance
+        expect(request_stub).to have_been_made
+      end
+
+      it "can get several models" do
+        request_stub = stub_request(:get, "#{base_url}/foos?some_param=12").to_return(
+          body: '["result"]',
+          headers: {"content-type" => "application/json; charset=utf-8"},
+        )
+        expect(model).to receive(:parse).with("result").and_return(model_instance)
+        expect(connection.get_multiple(model, "foos", some_param: 12)).to eq [model_instance]
+        expect(request_stub).to have_been_made
+      end
+    end
+
+    describe "creating" do
+      it "can create models" do
+        encoding = "".encoding
+
+        stub_request(:post, "#{base_url}/foos").with(
+          headers: {"content-type" => "application/json; charset=#{encoding}"},
+          body: {"title" => "Bar"}.to_json,
+        ).to_return(
+          status: 201, # Created
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+            "Location" => "#{base_url}/foos/1"
+          }
+        )
+
+        stub_request(:get, "#{base_url}/foos/1").to_return(
+          headers: {"content-type" => "application/json; charset=utf-8"},
+          body: {id: 1, title: "Bar"}.to_json,
+        )
+
+        expect(model).to receive(:parse).with(
+          "id" => 1, "title" => "Bar"
+        ).and_return(model_instance)
+
+        response = connection.create(model, "foos", title: "Bar")
+        expect(response).to eq model_instance
+      end
+
+      it "can ignore the response" do
+        encoding = "".encoding
+
+        stub_request(:post, "#{base_url}/foos").with(
+          headers: {"content-type" => "application/json; charset=#{encoding}"},
+          body: {"title" => "Bar"}.to_json,
+        ).to_return(
+          status: 201, # Created
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+            "Location" => "#{base_url}/foos/1"
+          }
+        )
+
+        response = connection.create_without_response("foos", title: "Bar")
+        expect(response).to be true
+      end
+
+      it "can pass extra parameters when following redirect" do
+        encoding = "".encoding
+
+        stub_request(:post, "#{base_url}/foos").with(
+          headers: {"content-type" => "application/json; charset=#{encoding}"},
+          body: {"title" => "Bar"}.to_json,
+        ).to_return(
+          status: 201, # Created
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+            "Location" => "#{base_url}/foos/1"
+          }
+        )
+
+        redirect = stub_request(:get, "#{base_url}/foos/1?extra=param").to_return(
+          headers: {"content-type" => "application/json; charset=utf-8"},
+          body: "{}",
+        )
+
+        connection.create(model, "foos", {title: "Bar"}, redirect_params: {extra: "param"})
+        expect(redirect).to have_been_made
+      end
+    end
+
+    describe "patching" do
+      it "can patch models" do
+        encoding = "".encoding
+
+        stub_request(:patch, "#{base_url}/foos/1").with(
+          headers: {"content-type" => "application/json; charset=#{encoding}"},
+          body: {"title" => "Bar"}.to_json,
+        ).to_return(
+          headers: {"content-type" => "application/json; charset=utf-8"},
+          body: {id: 1, title: "Bar"}.to_json,
+        )
+
+        expect(model).to receive(:parse).with(
+          "id" => 1, "title" => "Bar"
+        ).and_return(model_instance)
+
+        response = connection.patch(model, "foos/1", title: "Bar")
+        expect(response).to eq model_instance
+      end
+
+      it "can ignore responses" do
+        encoding = "".encoding
+
+        stub_request(:patch, "#{base_url}/foos/1").with(
+          headers: {"content-type" => "application/json; charset=#{encoding}"},
+          body: {"title" => "Bar"}.to_json,
+        ).to_return(
+          headers: {"content-type" => "application/json; charset=utf-8"},
+          body: {id: 1, title: "Bar"}.to_json,
+        )
+
+        response = connection.patch_without_response("foos/1", title: "Bar")
+        expect(response).to be true
+      end
+    end
+
+    describe "deleting" do
+      it "can delete paths" do
+        encoding = "".encoding
+
+        stub_request(:delete, "#{base_url}/foos/1").with(
+          headers: {"content-type" => "application/json; charset=#{encoding}"},
+          body: {"force" => true}.to_json,
+        ).to_return(
+          headers: {"content-type" => "application/json; charset=utf-8"},
+          body: {status: "Heyhoo! Nice one!"}.to_json,
+        )
+
+        response = connection.delete("foos/1", force: true)
+        expect(response).to be true
+      end
     end
   end
 end

--- a/spec/integration/category_assignment_spec.rb
+++ b/spec/integration/category_assignment_spec.rb
@@ -4,20 +4,6 @@ describe "Category assignment" do
   setup_integration_client
   let(:existing_post) { find_existing_post }
 
-  it "is possible on a post" do
-    new_category = client.create_category(name: "Post assignment 1")
-    client.assign_category_to_post(post_id: existing_post.id, category_id: new_category.id)
-    expect(client.find_post(existing_post.id).categories).to include new_category
-  end
-
-  it "can be removed on a post" do
-    new_category = client.create_category(name: "Post assignment 2")
-    client.assign_category_to_post(post_id: existing_post.id, category_id: new_category.id)
-
-    client.remove_category_from_post(post_id: existing_post.id, category_id: new_category.id)
-    expect(client.find_post(existing_post.id).categories).to_not include(new_category)
-  end
-
   it "can be set for multiple categories when creating a post" do
     category = client.create_category(name: "Assignment test 1")
     post = client.create_post(category_ids: [category.id], title: "Assignment test")

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -4,7 +4,7 @@ describe Wpclient::Post do
   let(:fixture) { json_fixture("simple-post.json") }
 
   it "can be parsed from JSON data" do
-    post = Wpclient::Post.new(fixture)
+    post = Wpclient::Post.parse(fixture)
 
     expect(post.id).to eq 1
     expect(post.title).to eq "Hello world!"
@@ -27,7 +27,7 @@ describe Wpclient::Post do
   end
 
   it "parses categories" do
-    post = Wpclient::Post.new(fixture)
+    post = Wpclient::Post.parse(fixture)
 
     expect(post.categories).to eq [
       Wpclient::Category.new(
@@ -40,7 +40,7 @@ describe Wpclient::Post do
 
   describe "dates" do
     it "uses GMT times if available" do
-      post = Wpclient::Post.new(fixture.merge(
+      post = Wpclient::Post.parse(fixture.merge(
         "date_gmt" => "2001-01-01T15:00:00",
         "date" => "2001-01-01T12:00:00",
         "modified_gmt" => "2001-01-01T15:00:00",
@@ -52,7 +52,7 @@ describe Wpclient::Post do
     end
 
     it "falls back to local time if no GMT date is provided" do
-      post = Wpclient::Post.new(fixture.merge(
+      post = Wpclient::Post.parse(fixture.merge(
         "date_gmt" => nil,
         "date" => "2001-01-01T12:00:00",
         "modified_gmt" => nil,
@@ -66,23 +66,23 @@ describe Wpclient::Post do
 
   describe "metadata" do
     it "is parsed into a hash" do
-      post = Wpclient::Post.new(json_fixture("post-with-metadata.json"))
+      post = Wpclient::Post.parse(json_fixture("post-with-metadata.json"))
       expect(post.meta).to eq "foo" => "bar"
     end
 
     it "raises UnauthorizedError when post it is forbidden" do
       expect {
-        Wpclient::Post.new(json_fixture("post-with-forbidden-metadata.json"))
+        Wpclient::Post.parse(json_fixture("post-with-forbidden-metadata.json"))
       }.to raise_error(Wpclient::UnauthorizedError)
     end
 
     it "keeps track of the ID of each metadata key" do
-      post = Wpclient::Post.new(json_fixture("post-with-metadata.json"))
+      post = Wpclient::Post.parse(json_fixture("post-with-metadata.json"))
       expect(post.meta_id_for("foo")).to eq 2
     end
 
     it "raises ArgumentError when asked for the meta ID of a meta key not present" do
-      post = Wpclient::Post.new(json_fixture("post-with-metadata.json"))
+      post = Wpclient::Post.parse(json_fixture("post-with-metadata.json"))
       expect {
         post.meta_id_for("clearly unreal")
       }.to raise_error(ArgumentError, /clearly unreal/)

--- a/spec/replace_categories_spec.rb
+++ b/spec/replace_categories_spec.rb
@@ -3,22 +3,22 @@ require "spec_helper"
 module Wpclient
   describe ReplaceCategories do
     it "adds missing categories" do
-      client = double(Client)
+      connection = double(Connection)
       post = double(Post, id: 40, category_ids: [1])
 
-      expect(client).to receive(:assign_category_to_post).with(post_id: 40, category_id: 5)
+      expect(connection).to receive(:create_without_response).with("posts/40/terms/category/5", {})
 
-      ReplaceCategories.call(client, post, [1, 5])
+      ReplaceCategories.call(connection, post, [1, 5])
     end
 
     it "removes extra categories" do
-      client = double(Client)
+      connection = double(Connection)
       post = double(Post, id: 40, category_ids: [8, 9, 10])
 
-      expect(client).to receive(:remove_category_from_post).with(post_id: 40, category_id: 8)
-      expect(client).to receive(:remove_category_from_post).with(post_id: 40, category_id: 9)
+      expect(connection).to receive(:delete).with("posts/40/terms/category/8", force: true)
+      expect(connection).to receive(:delete).with("posts/40/terms/category/9", force: true)
 
-      ReplaceCategories.call(client, post, [10])
+      ReplaceCategories.call(connection, post, [10])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@ RSpec.configure do |config|
   config.extend IntegrationMacros
   config.include Fixtures
 
+  config.run_all_when_everything_filtered = true
+
   config.before do
     WebMock.disable_net_connect!(allow_localhost: false)
   end


### PR DESCRIPTION
This splits `Client` into two classes: `Client` and `Connection`. `Connection`'s responsibility is to map simple method calls into their correct REST calls over the network. It hides the entire network from the `Client`, which can now focus on the exact REST calls that should be called instead.

`Connection` knows nothing about `Post`, `Category`, metadata, etc. It only knows how to perform the calls over the network.

`Client` does not know where the Wordpress server is located, how to connect to it or exactly how a create with `Location` works; it just passes the model that should be used to parse the response and let `Connection` handle the serialization and deserialization.

This makes it a lot easier to add more endpoints soon, it reduces the public API of `Client`, and it increases test coverage.

I've left a few examples without an implementation to get this rather large refactoring out. The examples were not there before I started working on this, so nothing has been lost – I just added markers for "these should be implemented".

CC @rmeritz 