### PR TITLE
Fetch by category

### DIFF
--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -7,8 +7,12 @@ module Wpclient
       @connection = connection
     end
 
-    def posts(per_page: 10, page: 1)
-      connection.get_multiple(Post, "posts", per_page: per_page, page: page, _embed: nil)
+    def posts(per_page: 10, page: 1, category_slug: nil)
+      filter = {}
+      filter[:category_name] = category_slug if category_slug
+      connection.get_multiple(
+        Post, "posts", per_page: per_page, page: page, _embed: nil, filter: filter
+      )
     end
 
     def find_post(id)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -20,9 +20,6 @@ describe Wpclient::Client do
 
       expect(client.posts).to eq []
     end
-
-    it "can find using a slug"
-    it "raises NotFoundError when trying to find by slug yields no posts"
   end
 
   describe "fetching a single post" do
@@ -34,6 +31,26 @@ describe Wpclient::Client do
       ).and_return post
 
       expect(client.find_post(5)).to eq post
+    end
+
+    it "can find using a slug" do
+      post = instance_double(Wpclient::Post)
+
+      expect(connection).to receive(:get_multiple).with(
+        Wpclient::Post, "posts", hash_including(filter: {name: "my-slug"})
+      ).and_return [post]
+
+      expect(client.find_by_slug("my-slug")).to eq post
+    end
+
+    it "raises NotFoundError when trying to find by slug yields no posts" do
+      expect(connection).to receive(:get_multiple).with(
+        Wpclient::Post, "posts", hash_including(filter: {name: "my-slug"}, per_page: 1)
+      ).and_return []
+
+      expect {
+        client.find_by_slug("my-slug")
+      }.to raise_error(Wpclient::NotFoundError, /my-slug/)
     end
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -20,6 +20,14 @@ describe Wpclient::Client do
 
       expect(client.posts).to eq []
     end
+
+    it "can filter on category slugs" do
+      expect(connection).to receive(:get_multiple).with(
+        Wpclient::Post, "posts", hash_including(filter: {category_name: "my-cat"})
+      ).and_return []
+
+      expect(client.posts(category_slug: "my-cat")).to eq []
+    end
   end
 
   describe "fetching a single post" do

--- a/spec/integration/posts_finding_spec.rb
+++ b/spec/integration/posts_finding_spec.rb
@@ -3,6 +3,17 @@ require "spec_helper"
 describe "Posts (finding)" do
   setup_integration_client
 
+  it "can list articles in a specific category" do
+    category = client.create_category(name: "Filtering time", slug: "filtering")
+    post = client.create_post(
+      category_ids: [category.id],
+      status: "publish",
+      title: "Some title",
+    )
+
+    expect(client.posts(category_slug: "filtering").map(&:id)).to eq [post.id]
+  end
+
   describe "finding by slug" do
     it "finds the matching post" do
       post = client.create_post(title: "Oh hai", slug: "oh-hai")


### PR DESCRIPTION
CC @rmeritz 

Pass `category_slug: "foo"` to the `posts` method to only get posts from that category slug back.