### PR TITLE
Pagination methods

### DIFF
--- a/lib/wpclient.rb
+++ b/lib/wpclient.rb
@@ -5,6 +5,7 @@ require "wpclient/connection"
 require "wpclient/client"
 require "wpclient/category"
 require "wpclient/post"
+require "wpclient/paginated_collection"
 
 require "wpclient/post_parser"
 

--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -16,7 +16,9 @@ module Wpclient
     end
 
     def find_by_slug(slug)
-      posts = connection.get_multiple(Post, "posts", per_page: 1, filter: {name: slug}, _embed: nil)
+      posts = connection.get_multiple(
+        Post, "posts", per_page: 1, page: 1, filter: {name: slug}, _embed: nil
+      )
       if posts.size > 0
         posts.first
       else

--- a/lib/wpclient/paginated_collection.rb
+++ b/lib/wpclient/paginated_collection.rb
@@ -1,0 +1,68 @@
+module Wpclient
+  class PaginatedCollection
+    include Enumerable
+    attr_reader :total, :current_page, :per_page
+
+    def initialize(entries, total:, current_page:, per_page:)
+      @entries = entries
+      @total = total
+      @current_page = current_page
+      @per_page = per_page
+    end
+
+    def each
+      if block_given?
+        @entries.each { |e| yield e }
+      else
+        @entries.each
+      end
+    end
+
+    #
+    # Pagination methods. Fulfilling will_paginate protocol
+    #
+
+    def total_pages
+      if total.zero? || per_page.zero?
+        0
+      else
+        (total / per_page.to_f).ceil
+      end
+    end
+
+    def next_page
+      if current_page < total_pages
+        current_page + 1
+      end
+    end
+
+    def previous_page
+      if current_page > 1
+        current_page - 1
+      end
+    end
+
+    def out_of_bounds?
+      current_page < 1 || current_page > total_pages
+    end
+
+    #
+    # Array-like behavior
+    #
+
+    def size
+      @entries.size
+    end
+
+    def empty?
+      @entries.empty?
+    end
+
+    def to_a
+      @entries
+    end
+
+    # Allow PaginatedCollection to be coerced into an array
+    alias to_ary to_a
+  end
+end

--- a/spec/paginated_collection_spec.rb
+++ b/spec/paginated_collection_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+
+module Wpclient
+  describe PaginatedCollection do
+    it "wraps an array" do
+      list = ["one"]
+      pagination = PaginatedCollection.new(list, total: 1, per_page: 1, current_page: 1)
+
+      expect(pagination.each.to_a).to eq list
+      expect(pagination.to_a).to eq list
+      expect(pagination.to_ary).to eq list
+
+      expect(pagination.total).to eq 1
+      expect(pagination.per_page).to eq 1
+      expect(pagination.current_page).to eq 1
+    end
+
+    it "can be coerced into an array" do
+      pagination = PaginatedCollection.new([1], total: 1, per_page: 1, current_page: 1)
+      expect([2] + pagination).to eq [2, 1]
+    end
+
+    it "is enumerable" do
+      expect(
+        PaginatedCollection.new([], total: 0, per_page: 1, current_page: 1)
+      ).to be_kind_of(Enumerable)
+    end
+
+    it "is as large as the array" do
+      expect(
+        PaginatedCollection.new([1, 2, 3], total: 0, per_page: 1, current_page: 1).size
+      ).to eq 3
+    end
+
+    describe "pagination attributes" do
+      def collection(total: 1, per_page: 1, current_page: 1)
+        PaginatedCollection.new([], total: total, per_page: per_page, current_page: current_page)
+      end
+
+      it "includes total pages" do
+        expect(collection(total: 10, per_page: 5).total_pages).to eq 2
+        expect(collection(total: 11, per_page: 5).total_pages).to eq 3
+        expect(collection(total:  0, per_page: 5).total_pages).to eq 0
+        expect(collection(total: 10, per_page: 0).total_pages).to eq 0
+        expect(collection(total:  2, per_page: 9).total_pages).to eq 1
+      end
+
+      it "includes next page number" do
+        expect(collection(total: 10, per_page: 1, current_page:  1).next_page).to eq 2
+        expect(collection(total: 10, per_page: 1, current_page:  9).next_page).to eq 10
+        expect(collection(total: 10, per_page: 1, current_page: 10).next_page).to eq nil
+
+        expect(collection(total: 10, per_page: 0, current_page: 1).next_page).to eq nil
+      end
+
+      it "includes previous page number" do
+        expect(collection(total: 10, per_page: 1, current_page: 10).previous_page).to eq 9
+        expect(collection(total: 10, per_page: 1, current_page:  2).previous_page).to eq 1
+        expect(collection(total: 10, per_page: 1, current_page:  1).previous_page).to eq nil
+      end
+
+      it "is out of bounds if current page is after last page" do
+        expect(collection(total: 2, per_page: 1, current_page: 1)).to_not be_out_of_bounds
+        expect(collection(total: 2, per_page: 1, current_page: 2)).to_not be_out_of_bounds
+
+        expect(collection(total: 2, per_page: 1, current_page: 3)).to be_out_of_bounds
+        expect(collection(total: 2, per_page: 1, current_page: 0)).to be_out_of_bounds
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds `total_pages`, `total`, `current_page`, `next_page`, `previous_page`, `out_of_bounds?`, and `per_page` on the collection returned by `Client#posts` and `Client#categories`. These methods are straight from `will_paginate`, the de-facto standard of pagination APIs.

CC @rmeritz 