### PR TITLE
Be compatible with will_paginate < 3.0

### DIFF
--- a/lib/wpclient/paginated_collection.rb
+++ b/lib/wpclient/paginated_collection.rb
@@ -52,6 +52,15 @@ module Wpclient
       current_page < 1 || current_page > total_pages
     end
 
+    # will_paginate < 3.0 has this method
+    def offset
+      if current_page > 0
+        (current_page - 1) * per_page
+      else
+        0
+      end
+    end
+
     #
     # Array-like behavior
     #

--- a/lib/wpclient/paginated_collection.rb
+++ b/lib/wpclient/paginated_collection.rb
@@ -10,8 +10,6 @@ module Wpclient
       @per_page = per_page
     end
 
-    alias total_entries total
-
     def each
       if block_given?
         @entries.each { |e| yield e }
@@ -27,6 +25,8 @@ module Wpclient
     #
     # Pagination methods. Fulfilling will_paginate protocol
     #
+
+    alias total_entries total
 
     def total_pages
       if total.zero? || per_page.zero?

--- a/spec/paginated_collection_spec.rb
+++ b/spec/paginated_collection_spec.rb
@@ -74,6 +74,16 @@ module Wpclient
         expect(collection(total: 2, per_page: 1, current_page: 3)).to be_out_of_bounds
         expect(collection(total: 2, per_page: 1, current_page: 0)).to be_out_of_bounds
       end
+
+      # Only to be compatible with will_paginate < 3.0
+      it "has an offset" do
+        expect(collection(per_page:  5, current_page: 1).offset).to eq 0
+        expect(collection(per_page:  5, current_page: 2).offset).to eq 5
+        expect(collection(per_page: 50, current_page: 3).offset).to eq 100
+
+        expect(collection(per_page: 50, current_page: 0).offset).to eq 0
+        expect(collection(per_page:  0, current_page: 0).offset).to eq 0
+      end
     end
   end
 end


### PR DESCRIPTION
CC @rmeritz 

[Methods on will_paginate 3.0-stable](https://github.com/mislav/will_paginate/blob/3-0-stable/lib/will_paginate/collection.rb):
* `current_page`
* `per_page`
* `total_entries`
* `total_pages`
* `out_of_bounds?`
* `previous_page`
* `next_page`
* `total_entries=` (not supported)
* `replace`

[Methods on will_paginate 2.3-stable](https://github.com/mislav/will_paginate/blob/2-3-stable/lib/will_paginate/collection.rb):
* `current_page`
* `per_page`
* `total_entries`
* `total_pages`
* `out_of_bounds?`
* <ins>`offset`</ins>
* `previous_page`
* `next_page`
* `total_entries=` (not supported)
* `replace`