### PR TITLE
Add `client.delete_post`

### DIFF
--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -114,11 +114,7 @@ module Wpclient
     end
 
     def delete_post(id, force: false)
-      attrs = {}
-      if force
-        attrs["force"] = true
-      end
-      connection.delete("posts/#{id.to_i}", attrs)
+      connection.delete("posts/#{id.to_i}", {"force" => force})
     end
 
     def inspect

--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -113,8 +113,12 @@ module Wpclient
       end
     end
 
-    def delete_post(id)
-      connection.delete("posts/#{id.to_i}", {"force" => true})
+    def delete_post(id, force: false)
+      attrs = {}
+      if force
+        attrs["force"] = true
+      end
+      connection.delete("posts/#{id.to_i}", attrs)
     end
 
     def inspect

--- a/lib/wpclient/client.rb
+++ b/lib/wpclient/client.rb
@@ -113,6 +113,10 @@ module Wpclient
       end
     end
 
+    def delete_post(id)
+      connection.delete("posts/#{id.to_i}", {"force" => true})
+    end
+
     def inspect
       "#<Wpclient::Client #{connection.inspect}>"
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -236,10 +236,26 @@ describe Wpclient::Client do
   describe "deleting posts" do
     it "requests that the client delete a post" do
       expect(connection).to receive(:delete).with(
-        "posts/1", {"force" => true}
+        "posts/1", {}
       ).and_return true
 
       expect(client.delete_post(1)).to eq true
+    end
+
+    it "requests that a client does not forcefully delete a post" do
+      expect(connection).to receive(:delete).with(
+        "posts/1", {}
+      ).and_return true
+
+      expect(client.delete_post(1, force: false)).to eq true
+    end
+
+    it "requests that a client forcefully deletes a post" do
+      expect(connection).to receive(:delete).with(
+        "posts/1", {"force" => true}
+      ).and_return true
+
+      expect(client.delete_post(1, force: true)).to eq true
     end
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -233,6 +233,16 @@ describe Wpclient::Client do
     end
   end
 
+  describe "deleting posts" do
+    it "requests that the client delete a post" do
+      expect(connection).to receive(:delete).with(
+        "posts/1", {"force" => true}
+      ).and_return true
+
+      expect(client.delete_post(1)).to eq true
+    end
+  end
+
   describe "categories" do
     it "can be listed" do
       expect(connection).to receive(:get_multiple).with(

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -234,23 +234,23 @@ describe Wpclient::Client do
   end
 
   describe "deleting posts" do
-    it "requests that the client delete a post" do
+    it "deletes a post without force by default" do
       expect(connection).to receive(:delete).with(
-        "posts/1", {}
+        "posts/1", {"force" => false}
       ).and_return true
 
       expect(client.delete_post(1)).to eq true
     end
 
-    it "requests that a client does not forcefully delete a post" do
+    it "deletes a post without force" do
       expect(connection).to receive(:delete).with(
-        "posts/1", {}
+        "posts/1", {"force" => false}
       ).and_return true
 
       expect(client.delete_post(1, force: false)).to eq true
     end
 
-    it "requests that a client forcefully deletes a post" do
+    it "deletes a post with force" do
       expect(connection).to receive(:delete).with(
         "posts/1", {"force" => true}
       ).and_return true

--- a/spec/integration/posts_crud_spec.rb
+++ b/spec/integration/posts_crud_spec.rb
@@ -77,11 +77,27 @@ describe "Posts (CRUD)" do
     ).to eq '<p class="hello-world">Hello world</p>'
   end
 
-  it "can delete posts" do
+  it "can move a post to the trash can" do
     post = find_existing_post
 
     expect(
       client.delete_post(post.id)
+    ).to eq true
+
+    # Post is in the trash can but still exists
+    # The status of a post is not exposed via the API so this behavior can not
+    # clearly be shown via the test
+    # https://github.com/WP-API/WP-API/issues/1760
+    expect(
+      client.find_post(post.id).id
+    ).to eq post.id
+  end
+
+  it "can permanently delete a post" do
+    post = find_existing_post
+
+    expect(
+      client.delete_post(post.id, force: true)
     ).to eq true
 
     expect {

--- a/spec/integration/posts_crud_spec.rb
+++ b/spec/integration/posts_crud_spec.rb
@@ -77,6 +77,30 @@ describe "Posts (CRUD)" do
     ).to eq '<p class="hello-world">Hello world</p>'
   end
 
+  it "can delete posts" do
+    post = find_existing_post
+
+    expect(
+      client.delete_post(post.id)
+    ).to eq true
+
+    expect {
+      client.find_post(post.id)
+    }.to raise_error(Wpclient::NotFoundError)
+  end
+
+  it "raises an error when deleting a post that does not exist" do
+    post_id = 99999999
+
+    expect {
+      client.find_post(post_id)
+    }.to raise_error(Wpclient::NotFoundError)
+
+    expect {
+      client.delete_post(99999999)
+    }.to raise_error(Wpclient::NotFoundError)
+  end
+
   def find_existing_post
     posts = client.posts(per_page: 1)
     expect(posts).to_not be_empty


### PR DESCRIPTION
Deletes a post with force (regardless of if it is published or not).