### PR TITLE
Expose embedded featured image

### DIFF
--- a/lib/wpclient/media.rb
+++ b/lib/wpclient/media.rb
@@ -31,5 +31,7 @@ module Wpclient
       @link = link
       @media_details = media_details
     end
+
+    alias source_url guid
   end
 end

--- a/lib/wpclient/media_parser.rb
+++ b/lib/wpclient/media_parser.rb
@@ -16,6 +16,7 @@ module Wpclient
       assign_basic(media)
       assign_dates(media)
       assign_rendered(media)
+      assign_guid(media)
 
       media
     end
@@ -27,8 +28,8 @@ module Wpclient
       media.id = data.fetch("id")
       media.slug = data.fetch("slug")
       media.link = data.fetch("link")
-      media.description = data.fetch("description")
-      media.media_details = data.fetch("media_details")
+      media.description = data["description"]
+      media.media_details = data["media_details"]
     end
 
     def assign_dates(media)
@@ -38,7 +39,10 @@ module Wpclient
 
     def assign_rendered(media)
       media.title = rendered("title")
-      media.guid = rendered("guid")
+    end
+
+    def assign_guid(media)
+      media.guid = rendered("guid") || data["source_url"]
     end
   end
 end

--- a/lib/wpclient/post.rb
+++ b/lib/wpclient/post.rb
@@ -6,7 +6,7 @@ module Wpclient
       :id, :title, :slug, :url, :guid,
       :excerpt_html, :content_html,
       :updated_at, :date,
-      :categories, :tags, :meta
+      :categories, :tags, :meta, :featured_image
     )
 
     def self.parse(data)
@@ -24,6 +24,7 @@ module Wpclient
       date: nil,
       categories: [],
       tags: [],
+      featured_image: nil,
       meta: {},
       meta_ids: {}
     )
@@ -37,6 +38,7 @@ module Wpclient
       @date = date
       @categories = categories
       @tags = tags
+      @featured_image = featured_image
       @meta = meta
       @meta_ids = meta_ids
     end
@@ -44,6 +46,10 @@ module Wpclient
     def category_ids() categories.map(&:id) end
 
     def tag_ids() tags.map(&:id) end
+
+    def featured_image_id
+      featured_image && featured_image.id
+    end
 
     def meta_id_for(key)
       @meta_ids[key] || raise(ArgumentError, "Post does not have meta #{key.inspect}")

--- a/lib/wpclient/post_parser.rb
+++ b/lib/wpclient/post_parser.rb
@@ -19,6 +19,7 @@ module Wpclient
       assign_rendered(post)
       assign_categories(post)
       assign_tags(post)
+      assign_featured_image(post)
 
       post
     end
@@ -50,6 +51,17 @@ module Wpclient
     def assign_tags(post)
       post.tags = embedded_terms("post_tag").map do |tag|
         Tag.parse(tag)
+      end
+    end
+
+    def assign_featured_image(post)
+      featured_id = data["featured_image"]
+      if featured_id
+        attachments = (embedded["http://v2.wp-api.org/attachment"] || []).flatten
+        media = attachments.detect { |attachment| attachment["id"] == featured_id }
+        if media
+          post.featured_image = Media.parse(media)
+        end
       end
     end
 

--- a/spec/integration/posts_with_attachments_spec.rb
+++ b/spec/integration/posts_with_attachments_spec.rb
@@ -7,8 +7,10 @@ describe "Posts with attachments" do
     media = find_or_upload_media
     post = client.create_post(title: "With media", featured_image: media.id)
 
-    pending
-    expect(post.featured_image).to eq media
+    expect(post.featured_image).to be_instance_of(Wpclient::Media)
+    expect(post.featured_image.slug).to eq media.slug
+    expect(post.featured_image.guid).to eq media.guid
+    expect(post.featured_image.source_url).to eq media.source_url
     expect(post.featured_image_id).to eq media.id
   end
 

--- a/spec/integration/posts_with_attachments_spec.rb
+++ b/spec/integration/posts_with_attachments_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "Posts with attachments" do
+  setup_integration_client
+
+  it "exposes featured image as a Media instance" do
+    media = find_or_upload_media
+    post = client.create_post(title: "With media", featured_image: media.id)
+
+    pending
+    expect(post.featured_image).to eq media
+    expect(post.featured_image_id).to eq media.id
+  end
+
+  def find_or_upload_media
+    client.media(per_page: 1).first ||
+      client.upload_file(fixture_path("thoughtful.jpg"), mime_type: "image/jpeg")
+  end
+end

--- a/spec/media_spec.rb
+++ b/spec/media_spec.rb
@@ -13,6 +13,7 @@ module Wpclient
       expect(media.description).to eq ""
 
       expect(media.guid).to eq "http://example.com/wp-content/uploads/2015/11/thoughtful.jpg"
+      expect(media.source_url).to eq "http://example.com/wp-content/uploads/2015/11/thoughtful.jpg"
       expect(media.link).to eq "http://example.com/?attachment_id=5"
 
       expect(media.date).to_not be_nil
@@ -21,6 +22,16 @@ module Wpclient
 
     it "exposes media information" do
       expect(Media.parse(fixture).media_details).to eq fixture.fetch("media_details")
+    end
+
+    it "tries to read guid from source_url if guid is not present" do
+      # This happens for associated attachments of posts, for example.
+      fixture.delete("guid")
+      fixture["source_url"] = "http://example.com/image.jpg"
+
+      media = Media.parse(fixture)
+      expect(media.guid).to eq "http://example.com/image.jpg"
+      expect(media.source_url).to eq "http://example.com/image.jpg"
     end
 
     describe "dates" do

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -51,6 +51,14 @@ describe Wpclient::Post do
     expect(post.tag_ids).to eq [2]
   end
 
+  it "can have a Media as featured image" do
+    media = instance_double(Wpclient::Media, id: 12)
+    post = Wpclient::Post.new(featured_image: media)
+
+    expect(post.featured_image).to eq media
+    expect(post.featured_image_id).to eq 12
+  end
+
   describe "dates" do
     it "uses GMT times if available" do
       post = Wpclient::Post.parse(fixture.merge(


### PR DESCRIPTION
This exposes `Post#featured_article` as a `Media` instance. It is populated from the list of embedded attachments in combination with the `featured_image` attribute in the response.

CC @rmeritz 