### PR TITLE
Post/Media title, and Term names are all HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ data = {
 
 post = client.create_post(data) # => Wpclient::Post
 updated_post = client.update_post(post.id, title: "Updated") # => Wpclient::Post
+
+updated_post.title_html # => "Updated"
 ```
 
 ## Running tests

--- a/lib/wpclient/media.rb
+++ b/lib/wpclient/media.rb
@@ -1,7 +1,7 @@
 module Wpclient
   class Media
     attr_accessor(
-      :id, :slug, :title, :description,
+      :id, :slug, :title_html, :description,
       :date, :updated_at,
       :guid, :link, :media_details
     )
@@ -13,7 +13,7 @@ module Wpclient
     def initialize(
       id: nil,
       slug: nil,
-      title: nil,
+      title_html: nil,
       description: nil,
       date: nil,
       updated_at: nil,
@@ -23,7 +23,7 @@ module Wpclient
     )
       @id = id
       @slug = slug
-      @title = title
+      @title_html = title_html
       @date = date
       @updated_at = updated_at
       @description = description

--- a/lib/wpclient/media_parser.rb
+++ b/lib/wpclient/media_parser.rb
@@ -38,7 +38,7 @@ module Wpclient
     end
 
     def assign_rendered(media)
-      media.title = rendered("title")
+      media.title_html = rendered("title")
     end
 
     def assign_guid(media)

--- a/lib/wpclient/post.rb
+++ b/lib/wpclient/post.rb
@@ -3,8 +3,8 @@ require "time"
 module Wpclient
   class Post
     attr_accessor(
-      :id, :title, :slug, :url, :guid, :status,
-      :excerpt_html, :content_html,
+      :id, :slug, :url, :guid, :status,
+      :title_html, :excerpt_html, :content_html,
       :updated_at, :date,
       :categories, :tags, :meta, :featured_image
     )
@@ -16,9 +16,9 @@ module Wpclient
     def initialize(
       id: nil,
       url: nil,
-      title: nil,
       guid: nil,
       status: "unknown",
+      title_html: nil,
       excerpt_html: nil,
       content_html: nil,
       updated_at: nil,
@@ -31,9 +31,9 @@ module Wpclient
     )
       @id = id
       @url = url
-      @title = title
       @guid = guid
       @status = status
+      @title_html = title_html
       @excerpt_html = excerpt_html
       @content_html = content_html
       @updated_at = updated_at

--- a/lib/wpclient/post_parser.rb
+++ b/lib/wpclient/post_parser.rb
@@ -41,8 +41,8 @@ module Wpclient
     end
 
     def assign_rendered(post)
-      post.title = rendered("title")
       post.guid = rendered("guid")
+      post.title_html = rendered("title")
       post.excerpt_html = rendered("excerpt")
       post.content_html = rendered("content")
     end

--- a/lib/wpclient/term.rb
+++ b/lib/wpclient/term.rb
@@ -1,18 +1,18 @@
 module Wpclient
   class Term
-    attr_reader :id, :name, :slug
+    attr_reader :id, :name_html, :slug
 
     def self.parse(data)
       new(
         id: data.fetch("id"),
-        name: data.fetch("name"),
+        name_html: data.fetch("name"),
         slug: data.fetch("slug"),
       )
     end
 
-    def initialize(id:, name:, slug:)
+    def initialize(id:, name_html:, slug:)
       @id = id
-      @name = name
+      @name_html = name_html
       @slug = slug
     end
 
@@ -20,7 +20,7 @@ module Wpclient
       if other.is_a? Term
         other.class == self.class &&
           other.id == id &&
-          other.name == name &&
+          other.name_html == name_html &&
           other.slug == slug
       else
         super
@@ -28,7 +28,7 @@ module Wpclient
     end
 
     def inspect
-      "#<#{self.class} ##{id} #{name.inspect} (#{slug})>"
+      "#<#{self.class} ##{id} #{name_html.inspect} (#{slug})>"
     end
   end
 end

--- a/spec/integration/attachments_crud_spec.rb
+++ b/spec/integration/attachments_crud_spec.rb
@@ -25,7 +25,7 @@ describe "Attachments" do
   it "can be updated" do
     media = find_or_create_attachment
     updated = client.update_media(media.id, title: "Totally updated media")
-    expect(updated.title).to eq "Totally updated media"
+    expect(updated.title_html).to eq "Totally updated media"
   end
 
   it "can be listed" do
@@ -35,6 +35,12 @@ describe "Attachments" do
 
     expect(media.size).to be > 0
     expect(media.first).to be_instance_of(Wpclient::Media)
+  end
+
+  it "uses HTML for the title" do
+    media = find_or_create_attachment
+    updated = client.update_media(media.id, title: "Images & paint")
+    expect(updated.title_html).to eq "Images &amp; paint"
   end
 
   def find_or_create_attachment

--- a/spec/integration/categories_spec.rb
+++ b/spec/integration/categories_spec.rb
@@ -10,7 +10,7 @@ describe "Categories" do
 
     category = post.categories.first
     expect(category.id).to be_kind_of(Integer)
-    expect(category.name).to be_instance_of(String)
+    expect(category.name_html).to be_instance_of(String)
     expect(category.slug).to be_instance_of(String)
 
     expect(post.category_ids).to eq post.categories.map(&:id)
@@ -22,7 +22,7 @@ describe "Categories" do
 
     category = categories.first
     expect(category.id).to be_kind_of(Integer)
-    expect(category.name).to be_instance_of(String)
+    expect(category.name_html).to be_instance_of(String)
     expect(category.slug).to be_instance_of(String)
   end
 
@@ -35,16 +35,21 @@ describe "Categories" do
     category = client.create_category(name: "New category")
 
     expect(category.id).to be_kind_of(Integer)
-    expect(category.name).to eq "New category"
+    expect(category.name_html).to eq "New category"
     expect(category.slug).to eq "new-category"
 
-    expect(client.categories(per_page: 100).map(&:name)).to include "New category"
+    expect(client.categories(per_page: 100).map(&:name_html)).to include "New category"
   end
 
   it "can be updated" do
     existing = find_existing_category
     client.update_category(existing.id, name: "Updated name")
-    expect(client.find_category(existing.id).name).to eq "Updated name"
+    expect(client.find_category(existing.id).name_html).to eq "Updated name"
+  end
+
+  it "uses HTML for the name" do
+    category = client.create_category(name: "Sort & Find")
+    expect(category.name_html).to eq "Sort &amp; Find"
   end
 
   def find_existing_category

--- a/spec/integration/posts_crud_spec.rb
+++ b/spec/integration/posts_crud_spec.rb
@@ -9,7 +9,7 @@ describe "Posts (CRUD)" do
 
     post = posts.first
     expect(post).to be_instance_of Wpclient::Post
-    expect(post.title).to be_instance_of(String)
+    expect(post.title_html).to be_instance_of(String)
   end
 
   it "can get specific posts" do
@@ -17,7 +17,7 @@ describe "Posts (CRUD)" do
 
     found_post = client.find_post(existing_post.id)
     expect(found_post.id).to eq existing_post.id
-    expect(found_post.title).to eq existing_post.title
+    expect(found_post.title_html).to eq existing_post.title_html
 
     expect { client.find_post(888888) }.to raise_error(Wpclient::NotFoundError)
   end
@@ -35,7 +35,7 @@ describe "Posts (CRUD)" do
     # Try to find the post to determine if it was persisted or not
     all_posts = client.posts(per_page: 100)
     expect(all_posts.map(&:id)).to include post.id
-    expect(all_posts.map(&:title)).to include "A newly created post"
+    expect(all_posts.map(&:title_html)).to include "A newly created post"
   end
 
   it "raises a validation error if post could not be created" do
@@ -49,7 +49,7 @@ describe "Posts (CRUD)" do
 
     client.update_post(post.id, title: "Updated title")
 
-    expect(client.find_post(post.id).title).to eq "Updated title"
+    expect(client.find_post(post.id).title_html).to eq "Updated title"
   end
 
   it "raises errors if post could not be updated" do
@@ -66,15 +66,12 @@ describe "Posts (CRUD)" do
 
   it "correctly handles HTML" do
     post = client.create_post(
-      title: "HTML test",
+      title: "HTML test & verify",
       content: '<p class="hello-world">Hello world</p>',
     )
 
     expect(post.content_html.strip).to eq '<p class="hello-world">Hello world</p>'
-
-    expect(
-      client.find_post(post.id).content_html.strip
-    ).to eq '<p class="hello-world">Hello world</p>'
+    expect(post.title_html.strip).to eq 'HTML test &amp; verify'
   end
 
   it "can move a post to the trash can" do

--- a/spec/integration/posts_metadata_spec.rb
+++ b/spec/integration/posts_metadata_spec.rb
@@ -19,4 +19,9 @@ describe "Post meta" do
     post = client.update_post(post.id, meta: {three: "3", two: nil})
     expect(post.meta).to eq("three" => "3")
   end
+
+  it "does not contain HTML data" do
+    post = client.create_post(title: "Metadata HTML", meta: {foo: "bar&baz"})
+    expect(post.meta).to eq("foo" => "bar&baz")
+  end
 end

--- a/spec/integration/tags_spec.rb
+++ b/spec/integration/tags_spec.rb
@@ -12,16 +12,21 @@ describe "Tags" do
     tag = client.create_tag(name: "New tag")
 
     expect(tag.id).to be_kind_of(Integer)
-    expect(tag.name).to eq "New tag"
+    expect(tag.name_html).to eq "New tag"
     expect(tag.slug).to eq "new-tag"
 
-    expect(client.tags(per_page: 100).map(&:name)).to include "New tag"
+    expect(client.tags(per_page: 100).map(&:name_html)).to include "New tag"
   end
 
   it "can be updated" do
     existing = find_or_create_tag
     client.update_tag(existing.id, name: "Updated name")
-    expect(client.find_tag(existing.id).name).to eq "Updated name"
+    expect(client.find_tag(existing.id).name_html).to eq "Updated name"
+  end
+
+  it "uses HTML for the name" do
+    tag = client.create_tag(name: "Sort & Find")
+    expect(tag.name_html).to eq "Sort &amp; Find"
   end
 
   def find_or_create_tag

--- a/spec/media_spec.rb
+++ b/spec/media_spec.rb
@@ -8,7 +8,7 @@ module Wpclient
       media = Media.parse(fixture)
 
       expect(media.id).to eq 5
-      expect(media.title).to eq "thoughtful"
+      expect(media.title_html).to eq "thoughtful"
       expect(media.slug).to eq "thoughtful"
       expect(media.description).to eq ""
 

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -7,7 +7,7 @@ describe Wpclient::Post do
     post = Wpclient::Post.parse(fixture)
 
     expect(post.id).to eq 1
-    expect(post.title).to eq "Hello world!"
+    expect(post.title_html).to eq "Hello world!"
     expect(post.slug).to eq "hello-world"
 
     expect(post.url).to eq "http://example.com/2015/11/03/hello-world/"
@@ -32,7 +32,7 @@ describe Wpclient::Post do
 
     expect(post.categories).to eq [
       Wpclient::Category.new(
-        id: 1, name: "Uncategorized", slug: "uncategorized"
+        id: 1, name_html: "Uncategorized", slug: "uncategorized"
       )
     ]
 
@@ -44,7 +44,7 @@ describe Wpclient::Post do
 
     expect(post.tags).to eq [
       Wpclient::Tag.new(
-        id: 2, name: "Foo", slug: "foo"
+        id: 2, name_html: "Foo", slug: "foo"
       )
     ]
 

--- a/spec/shared_examples/term_examples.rb
+++ b/spec/shared_examples/term_examples.rb
@@ -1,8 +1,8 @@
 shared_examples_for(Wpclient::Term) do |fixture_name:|
-  it "has an id, name and slug" do
-    term = described_class.new(id: 5, name: "Heyho", slug: "heyho")
+  it "has an id, name_html and slug" do
+    term = described_class.new(id: 5, name_html: "Heyho", slug: "heyho")
     expect(term.id).to eq 5
-    expect(term.name).to eq "Heyho"
+    expect(term.name_html).to eq "Heyho"
     expect(term.slug).to eq "heyho"
   end
 
@@ -10,28 +10,28 @@ shared_examples_for(Wpclient::Term) do |fixture_name:|
     term = described_class.parse(json_fixture(fixture_name))
     expect(term.id).to be_kind_of Integer
 
-    expect(term.name).to be_kind_of String
+    expect(term.name_html).to be_kind_of String
     expect(term.slug).to be_kind_of String
-    expect(term.name).to_not be_empty
+    expect(term.name_html).to_not be_empty
     expect(term.slug).to_not be_empty
   end
 
-  it "is equal to other instances with the same id, name and slug" do
-    instance = described_class.new(id: 1, name: "One", slug: "one")
-    copy     = described_class.new(id: 1, name: "One", slug: "one")
+  it "is equal to other instances with the same id, name_html and slug" do
+    instance = described_class.new(id: 1, name_html: "One", slug: "one")
+    copy     = described_class.new(id: 1, name_html: "One", slug: "one")
 
     expect(instance).to eq instance
     expect(instance).to eq copy
 
-    expect(instance).to_not eq described_class.new(id: 2, name: "One", slug: "one")
-    expect(instance).to_not eq described_class.new(id: 1, name: "Two", slug: "one")
-    expect(instance).to_not eq described_class.new(id: 1, name: "One", slug: "two")
+    expect(instance).to_not eq described_class.new(id: 2, name_html: "One", slug: "one")
+    expect(instance).to_not eq described_class.new(id: 1, name_html: "Two", slug: "one")
+    expect(instance).to_not eq described_class.new(id: 1, name_html: "One", slug: "two")
   end
 
-  it "it not equal on other Term subclasses with the same id, name and slug" do
+  it "it not equal on other Term subclasses with the same id, name_html and slug" do
     other_subclass = Class.new(Wpclient::Tag)
 
-    term = described_class.new(id: 1, name: "One", slug: "one")
-    expect(term).to_not eq other_subclass.new(id: 1, name: "One", slug: "one")
+    term = described_class.new(id: 1, name_html: "One", slug: "one")
+    expect(term).to_not eq other_subclass.new(id: 1, name_html: "One", slug: "one")
   end
 end


### PR DESCRIPTION
This should make that problem more obvious when using this gem.

@rmeritz what do you think about adding `#name` and `#title` variants that unescape the HTML? We could use Nokogiri for the task.