### PR TITLE
Release docker images to Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ updated_post.title_html # => "Updated"
 
 You need to install Docker and set it up for your machine. Note that you need `docker-machine` to run Docker on OS X.
 
-Run tests using the normal `rspec` command after installing all bundles. The first time the integration tests are run, a docker image will be built that hosts a Wordpress installation, but the image will be re-used on subsequent runs.
+Then build the docker image using `rake docker:build`.
+
+Run tests using the normal `rspec` command after installing all bundles.
 
 ```
 bundle exec rspec
@@ -51,6 +53,12 @@ end
 ```
 
 The normal `rspec` command will *not* use this filter in case it is ever committed accidentally, so CI can catch any problems.
+
+## Releasing a new version
+
+The normal gem release cycle works using `rake release`.
+
+If you make changes to the docker image, you can release it using `rake docker:release`.
 
 ## Copyright & License
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,32 @@
 require "bundler/gem_tasks"
+
+namespace :docker do
+  DOCKER_DIR = File.expand_path("../spec/docker", __FILE__).freeze
+  IMAGE_NAME = "hemnet/wordpress_client_test".freeze
+  DEV_IMAGE = [IMAGE_NAME, "dev"].join(":").freeze
+
+  desc "Build the docker image"
+  task :build do
+    sh "docker", "build", "-t", DEV_IMAGE, DOCKER_DIR
+  end
+
+  desc "Release current dev build"
+  task release: :build do
+    version = prompt "Which version do you want to release"
+    raise "Invalid version string" unless version =~ /\A[\d.]+\z/
+
+    latest = prompt "Do you want this to be the :latest release? [Y/n]"
+    latest = (latest.empty? || latest.downcase == "y")
+
+    sh "docker", "tag", DEV_IMAGE, "#{IMAGE_NAME}:#{version}"
+    sh "docker", "tag", "-f", DEV_IMAGE, "#{IMAGE_NAME}:latest" if latest
+
+    sh "docker", "push", "#{IMAGE_NAME}:#{version}"
+    sh "docker", "push", "#{IMAGE_NAME}:latest" if latest
+  end
+end
+
+def prompt(message)
+  print "#{message} > "
+  STDIN.gets.strip
+end

--- a/spec/docker/Dockerfile
+++ b/spec/docker/Dockerfile
@@ -13,11 +13,14 @@ ENV APP_USER admin
 ENV APP_PASS P@ssw0rd
 ENV WP_KEY ILoveFlappyjacks
 
+# Make pretty permalinks work so API is accessible
+COPY htaccess /var/www/html/wordpress/.htaccess
+
 # Restore a copy of a set up database on first boot
 COPY dbdump.sql.gz /tmp/dbdump.sql.gz
 COPY restore-dbdump.sh /tmp/.restore-dbdump.sh
 RUN chmod +x /tmp/.restore-dbdump.sh && \
-    echo "if [ -f /tmp/.restore-dbdump.sh ]; then /tmp/.restore-dbdump.sh; rm -fr /tmp/.restore-dbdump.sh; fi" >> /root/.bashrc
+    echo "if [ -f /tmp/.restore-dbdump.sh ]; then /tmp/.restore-dbdump.sh; rm /tmp/.restore-dbdump.sh; fi" >> /root/.bashrc
 
 ### Install API and API Basic Auth plugins
 
@@ -35,6 +38,3 @@ RUN curl -SL -o /tmp/rest-api.zip https://downloads.wordpress.org/plugin/rest-ap
 RUN curl -SL https://github.com/WP-API/Basic-Auth/archive/master.tar.gz \
   | tar -xzC /var/www/html/wordpress/wp-content/plugins/ \
   && mv /var/www/html/wordpress/wp-content/plugins/Basic-Auth* /var/www/html/wordpress/wp-content/plugins/basic-auth
-
-# Make pretty permalinks work so API is accessible
-COPY htaccess /var/www/html/wordpress/.htaccess

--- a/spec/docker/README.md
+++ b/spec/docker/README.md
@@ -1,15 +1,47 @@
-# How this was built
+# Docker image for WordpressClient
 
-## dbdump
+Use this docker image to run integration tests, either in this repo or in some client repo where you use the gem.
 
-If you need to regenerate the dbdump, remove the part where the file is copied and restored from the `Dockerfile`, then build and start the image.
+**Note:** This image is not meant for *any* production use. It's meant for integration tests, and nothing else.
+
+## Usage
+
+You need to publish the container's port 80 to whichever port you want your instance on, then set an environment variable for where the server should be accessible from as Wordpress needs to have this stored in the database.
+
+You also need to run it with an interactive terminal in order for it to work.
 
 ```bash
-docker build -t wpclient-test .
-docker run -it -p 8181:80 wpclient-test
+docker run -dit -p 8080:80 -e WORDPRESS_HOST=localhost:8080 hemnet/wordpress_client_test:latest
 ```
 
-You'll get a prompt inside the container. Open your browser and go to the newly booted application (`localhost:8181` if you have native Docker; otherwise go to your `$DOCKER_HOST_IP:8181` URL – see `echo $DOCKER_HOST` in your local shell).
+I you want to see the ouput or access the environment in order to debug an issue, omit the `-d` option. It will boot into a `bash` shell with Apache running in the background. You can also use `docker attach` to attach to a running instance.
+
+**Note:** When you exit a running container, everything stored in it will be kept on disk. It is recommended that you `docker rm` the image when you are done to clean up.
+
+When the instance is up and running, you can log in as an administrator using `test`/`test` as username and password.
+
+## Contents
+
+This image is based on Appcontainer's Wordpress image, which runs Apache, MySQL and PHP5 on CentOS using bash. In addition, a DB dump is restored containing a set up blog so you don't need to do the first installation steps.
+
+* Username `test`
+* Password `test`
+* Plugin `WP-API` is installed
+* Plugin `Basic-Auth` for `WP-API` installed
+* `.htaccess` for Pretty Permalinks is set up so the API works
+
+## Developing the image
+
+### Re-creating DB dump from scratch
+
+If you need to regenerate the DB dump, remove the part where the file is copied and restored from the `Dockerfile`, then build and start the image.
+
+```bash
+docker build -t wordpress_client_test:dev .
+docker run -it -p 8181:80 wordpress_client_test:dev
+```
+
+You'll get a `bash` shell inside the container. Open your browser and go to the newly booted application (`localhost:8181` if you have native Docker; otherwise go to your `DOCKER_HOST_IP:8181` URL – see `echo $DOCKER_HOST` in your local shell).
 
 You'll be greeted by the Wordpress installer. Fill in everything and complete the installation.
 
@@ -22,16 +54,11 @@ mysqldump -u "$MYSQL_USER" --password="$MYSQL_PASS" --host="$MYSQL_HOST" "$MYSQL
 You can then copy the file to your host using the `docker cp` command:
 
 ```bash
-docker ps | grep wpclient-test
+docker ps | grep wordpress_client_test:dev
 # See the container ID or name of your running container
 docker cp THE-CONTAINER-ID:/tmp/dbdump.sql.gz .
 ```
 
-You can then shut down your container by logging out of the container terminal.
+Last step is to update `restore-dbdump.sh` to replace the hard-coded `WORDPRESS_HOST` placeholder with the one you used to generate the DB dump with. This corresponds with `localhost:8181` with native Docker if you followed these commands exactly. If you use `docker-machine`, you need to use your machine IP instead. (See *"Usage"* above)
 
-Restore the DB loading code from the `Dockerfile`, commit this file to the repo and rebuild everything and verify that Wordpress is still set up correctly when the dump is restored.
-
-`spec/docker/restore-dbdump.sh` hard codes an expectation that the IP in your
-datadump is a specfic IP. So you will need to change that hard coded
-expectation to match the new IP used in your data dump. You can find out what
-that IP is by examining the dumo but it is probably the value set in `$DOCKER_HOST`.
+You can then shut down your container by logging out of the container terminal. Restore the DB loading code from the `Dockerfile`, commit this file to the repo and rebuild everything and verify that Wordpress is still set up correctly when the dump is restored.

--- a/spec/support/docker_runner.rb
+++ b/spec/support/docker_runner.rb
@@ -9,11 +9,15 @@ module DockerRunner
   end
 
   def image_exists?(name)
-    system("docker images | grep -q '^#{name.shellescape} '")
+    name, tag = name.split(":", 2)
+    matcher = "^#{name} "
+    matcher << "[[:space:]]*#{tag}" if tag
+
+    system("docker images | grep -q #{matcher.shellescape}")
   end
 
   def build_image(name, path: Dir.pwd)
-    system("cd #{path.shellescape} && docker build -t #{name.shellescape} .")
+    system("docker build -t #{name.shellescape} #{path.shellescape}")
   end
 
   def run_container(name, port:, environment: {})

--- a/spec/support/wordpress_server.rb
+++ b/spec/support/wordpress_server.rb
@@ -24,6 +24,8 @@ class WordpressServer
   def password() "test" end
 
   private
+  DOCKER_IMAGE_NAME = "hemnet/wordpress_client_test:dev".freeze
+
   def host_with_port
     "#{host}:#{port}"
   end
@@ -62,14 +64,14 @@ class WordpressServer
   end
 
   def build_container_if_missing
-    unless DockerRunner.image_exists?("wpclient-test")
-      DockerRunner.build_image("wpclient-test", path: "spec/docker")
+    unless DockerRunner.image_exists?(DOCKER_IMAGE_NAME)
+      DockerRunner.build_image(DOCKER_IMAGE_NAME, path: "spec/docker")
     end
   end
 
   def start_container
     DockerRunner.run_container(
-      "wpclient-test",
+      DOCKER_IMAGE_NAME,
       port: port,
       environment: {wordpress_host: host_with_port}
     )


### PR DESCRIPTION
This changes the used docker images from `wpclient-test` into `wordpress_client_test`, with the tags `dev` and `latest`. `dev` is only used locally to run the tests and what have you, while `latest` will be the latest version that has been released.

I've pushed `1.0` and `latest` tags to Docker Hub. Everything is handled using the `rake docker:release` task.

I changed the README so it asks you to build the image before you run the tests, but it's not a new requirement. I just wanted any build failures because of a bad environment to be shown in an isolated build command rather than in the middle of a test run.

CC @rmeritz @kolizz 